### PR TITLE
Replaced Windows-only PostBuild target in project settings with a cro…

### DIFF
--- a/Juniper/Juniper.fsproj
+++ b/Juniper/Juniper.fsproj
@@ -30,8 +30,8 @@
     <PackageReference Include="Symbolism" Version="1.0.4" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /e/i/y &quot;$(ProjectDir)junstd&quot; &quot;$(OutDir)junstd&quot;&#xD;&#xA;xcopy /e/i/y &quot;$(ProjectDir)cppstd&quot; &quot;$(OutDir)cppstd&quot;&#xD;&#xA;xcopy /e/i/y &quot;$(ProjectDir)examples&quot; &quot;$(OutDir)examples&quot;&#xD;&#xA;xcopy /e/i/y &quot;$(ProjectDir)wrappers&quot; &quot;$(OutDir)wrappers&quot;" />
-  </Target>
+  <ItemGroup>
+    <None Include="junstd/**;cppstd/**;examples/**;wrappers/**" CopyToOutputDirectory="Always" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Nixpkgs currently has an old version of Juniper (2.3.0), wrapped from the portable Linux zip. I've updated the Nix packaging script for 4.0.0, this time building from source. This required a change to the project file which was using xcopy to bring over junstd etc. I've replaced it with (hopefully cross-platform) functionality built into MSBuild, which (at least on my NixOS machine) copies those directories into both the build and publish directories. I'm not sure how you're producing your releases, so I haven't yet tried it in Visual Studio on Windows. Hopefully it just works, and if you're happy to merge, I can try to get the version in Nixpkgs updated.